### PR TITLE
release: 3.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,14 @@
+## [3.1.0](https://github.com/sketch7/signalr-client/compare/3.0.0...3.1.0) (2022-11-22)
+
+### Features
+
+- **hub connection:** ability to configure microsoft `HubConnection` directly via `configureSignalRHubConnection`
+
+### Bug Fixes
+
+- **hub connection:** correctly close the websocket connection when `disconnect` is called right after `connect`
+- **hub connection:** `connectionState$` `connecting` will also be set when connecting not only when reconnecting
+
 ## [3.0.0](https://github.com/sketch7/signalr-client/compare/2.0.0...3.0.0) (2021-04-30)
 
 ### Features

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ssv/signalr-client",
-  "version": "3.0.0",
+  "version": "3.1.0",
   "versionSuffix": "",
   "description": "SignalR client library built on top of @microsoft/signalr. This gives you more features and easier to use.",
   "homepage": "https://github.com/sketch7/signalr-client",

--- a/src/hub-connection.model.ts
+++ b/src/hub-connection.model.ts
@@ -1,4 +1,4 @@
-import { IHttpConnectionOptions, IHubProtocol } from "@microsoft/signalr";
+import { HubConnection, IHttpConnectionOptions, IHubProtocol } from "@microsoft/signalr";
 
 import { Dictionary } from "./utils/dictionary";
 
@@ -38,6 +38,10 @@ export interface HubConnectionOptions {
 	/** @internal */
 	getData?: () => Dictionary<string>;
 	protocol?: IHubProtocol;
+	/**
+	 * Configures the SignalR Hub connection after it has been built (raw) in order to access/configure `serverTimeoutInMilliseconds`, `keepAliveIntervalInMilliseconds` etc...
+	 */
+	configureSignalRHubConnection?: (hubConnection: HubConnection) => void;
 }
 
 export interface ConnectionOptions extends IHttpConnectionOptions {


### PR DESCRIPTION
### Features

- **hub connection:** ability to configure microsoft `HubConnection` directly via `configureSignalRHubConnection`

### Bug Fixes

- **hub connection:** correctly close the websocket connection when `disconnect` is called right after `connect`
- **hub connection:** `connectionState$` `connecting` will also be set when connecting not only when reconnecting